### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ In order to build your own App based on C2Call-SDK, create a new application in 
 
 https://www.c2call.com/en/how-it-works/ios-sdk.html
 
-With Cocoapods SDK, no additional steps for integrating the SDK are necessary.
+With CocoaPods SDK, no additional steps for integrating the SDK are necessary.
 Just add C2Call-SDK to your Podfile, run pod install and start implementation.
 
 The C2Call-SDK reference documentation can be found here:


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
